### PR TITLE
fix: replace deprecated useFormState in dev login (#16)

### DIFF
--- a/apps/web/src/routes/dev-login/client.tsx
+++ b/apps/web/src/routes/dev-login/client.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useFormState, useFormStatus } from "react-dom";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
 import { createAdminUser, type DevLoginState } from "./actions";
 import { Alert } from "@monorepo/design-system";
 import { Button } from "@monorepo/design-system";
 import { SimpleInput } from "@monorepo/design-system";
 
 export function CreateAdminForm() {
-	const [state, formAction] = useFormState<DevLoginState, FormData>(
+	const [state, formAction] = useActionState<DevLoginState, FormData>(
 		// Type assertion needed because server actions can return Response for redirects,
-		// but useFormState types don't reflect this capability yet
+		// but useActionState types don't reflect this capability yet
 		createAdminUser as (state: DevLoginState, payload: FormData) => Promise<DevLoginState>,
 		{}
 	);


### PR DESCRIPTION
## Summary
- replace useFormState with useActionState in the dev-login form to remove deprecation warnings
- keep existing server-action typing and submit behavior unchanged
- closes #16

## Testing
- cd apps/web && npm run check
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- low: localized hook migration in a single form component