### PR TITLE
fix: restore /floor/time-clock/mobile route (#18)

### DIFF
--- a/apps/web/src/__tests__/routes/floor/mobile-route.test.tsx
+++ b/apps/web/src/__tests__/routes/floor/mobile-route.test.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MobileFloorRoute from "~/routes/floor/time-clock/mobile/route";
+import { mockDb } from "~/__tests__/setup";
+
+vi.mock("~/lib/ensure-operational-data", () => ({
+	ensureOperationalDataSeeded: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("~/lib/operational-config", () => ({
+	getTaskAssignmentMode: vi.fn(() => Promise.resolve("MANAGER_ONLY")),
+}));
+
+describe("Floor mobile route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("loads and renders mobile clock data with minimal DTO fields", async () => {
+		mockDb.employee.findMany.mockResolvedValue([{ id: "emp-1", name: "Alice" }]);
+		mockDb.station.findMany.mockResolvedValue([{ id: "st-1", name: "PICKING" }]);
+		mockDb.timeLog.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+		mockDb.taskType.findMany.mockResolvedValue([]);
+		mockDb.taskAssignment.findMany.mockResolvedValue([]);
+
+		const node = await MobileFloorRoute();
+
+		expect(node).toBeDefined();
+		expect(mockDb.employee.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ select: { id: true, name: true } })
+		);
+		expect(mockDb.station.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ select: { id: true, name: true } })
+		);
+		expect(mockDb.timeLog.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				include: {
+					Employee: { select: { id: true, name: true } },
+					Station: { select: { id: true, name: true } },
+				},
+			})
+		);
+	});
+});

--- a/apps/web/src/routes/config.ts
+++ b/apps/web/src/routes/config.ts
@@ -63,17 +63,17 @@ export function routes(): RSCRouteConfig {
 							index: true,
 							lazy: () => import("./floor/route.tsx"),
 						},
-						{
-							id: "floor-time-clock-mobile",
-							path: "time-clock/mobile",
-							lazy: () => import("./floor/time-clock/mobile/route.tsx"),
-						},
 					],
 				},
 				{
 					id: "floor-kiosk",
 					path: "floor/kiosk",
 					lazy: () => import("./floor/kiosk/route.tsx"),
+				},
+				{
+					id: "floor-time-clock-mobile",
+					path: "floor/time-clock/mobile",
+					lazy: () => import("./floor/time-clock/mobile/route.tsx"),
 				},
 
 				// Manager experience (MANAGER, ADMIN roles)

--- a/apps/web/src/routes/floor/mobile-time-clock/client.tsx
+++ b/apps/web/src/routes/floor/mobile-time-clock/client.tsx
@@ -12,7 +12,7 @@ import {
 	MobileHeader,
 } from "./components/mobile-layout";
 import { Alert } from "@monorepo/design-system";
-import type { Employee, Station, TimeLog } from "@prisma/client";
+import type { Station_name, TimeLog } from "@prisma/client";
 import { clockIn, clockOut, startBreak, endBreak, pinToggleClock } from "../../time-clock/actions";
 import { useOnlineStatus, useOfflineActionQueue } from "~/lib/offline-support";
 import { notify } from "~/components/time-tracking/notifications";
@@ -26,9 +26,19 @@ import {
 	type TaskOption,
 } from "~/components/time-tracking/self-task-actions";
 
-type TimeLogWithRelations = TimeLog & {
-	employee: Employee;
-	station: Station | null;
+export type MobileEmployee = {
+	id: string;
+	name: string;
+};
+
+export type MobileStation = {
+	id: string;
+	name: Station_name;
+};
+
+export type MobileTimeLogWithRelations = TimeLog & {
+	employee: MobileEmployee;
+	station: MobileStation | null;
 };
 
 export function MobileTimeClock({
@@ -40,10 +50,10 @@ export function MobileTimeClock({
 	assignmentMode,
 	taskOptions,
 }: {
-	employees: Employee[];
-	stations: Station[];
-	activeLogs: TimeLogWithRelations[];
-	activeBreaks: TimeLogWithRelations[];
+	employees: MobileEmployee[];
+	stations: MobileStation[];
+	activeLogs: MobileTimeLogWithRelations[];
+	activeBreaks: MobileTimeLogWithRelations[];
 	activeTasksByEmployee?: Record<
 		string,
 		{ assignmentId: string; taskTypeName: string; stationName: string | null }

--- a/apps/web/src/routes/floor/time-clock/mobile/route.tsx
+++ b/apps/web/src/routes/floor/time-clock/mobile/route.tsx
@@ -1,7 +1,10 @@
 import { db } from "~/lib/db";
 import { ensureOperationalDataSeeded } from "~/lib/ensure-operational-data";
 import { getTaskAssignmentMode } from "~/lib/operational-config";
-import { MobileTimeClock } from "~/routes/floor/mobile-time-clock/client";
+import {
+	MobileTimeClock,
+	type MobileTimeLogWithRelations,
+} from "~/routes/floor/mobile-time-clock/client";
 
 export default async function Component() {
 	await ensureOperationalDataSeeded();
@@ -15,16 +18,29 @@ export default async function Component() {
 		activeTaskTypes,
 		activeAssignments,
 	] = await Promise.all([
-		db.employee.findMany({ orderBy: { name: "asc" } }),
-		db.station.findMany({ where: { isActive: true }, orderBy: { name: "asc" } }),
+		db.employee.findMany({
+			orderBy: { name: "asc" },
+			select: { id: true, name: true },
+		}),
+		db.station.findMany({
+			where: { isActive: true },
+			orderBy: { name: "asc" },
+			select: { id: true, name: true },
+		}),
 		db.timeLog.findMany({
 			where: { endTime: null, type: "WORK", deletedAt: null },
-			include: { Employee: true, Station: true },
+			include: {
+				Employee: { select: { id: true, name: true } },
+				Station: { select: { id: true, name: true } },
+			},
 			orderBy: { startTime: "desc" },
 		}),
 		db.timeLog.findMany({
 			where: { endTime: null, type: "BREAK", deletedAt: null },
-			include: { Employee: true, Station: true },
+			include: {
+				Employee: { select: { id: true, name: true } },
+				Station: { select: { id: true, name: true } },
+			},
 			orderBy: { startTime: "desc" },
 		}),
 		getTaskAssignmentMode(),
@@ -63,7 +79,9 @@ export default async function Component() {
 		return acc;
 	}, {});
 
-	const toMobileLog = (log: (typeof activeLogs)[number] | (typeof activeBreaks)[number]) => ({
+	const toMobileLog = (
+		log: (typeof activeLogs)[number] | (typeof activeBreaks)[number]
+	): MobileTimeLogWithRelations => ({
 		id: log.id,
 		startTime: log.startTime,
 		endTime: log.endTime,
@@ -81,12 +99,8 @@ export default async function Component() {
 		station: log.Station,
 	});
 
-	const mobileActiveLogs = activeLogs.map(toMobileLog) as Parameters<
-		typeof MobileTimeClock
-	>[0]["activeLogs"];
-	const mobileActiveBreaks = activeBreaks.map(toMobileLog) as Parameters<
-		typeof MobileTimeClock
-	>[0]["activeBreaks"];
+	const mobileActiveLogs = activeLogs.map(toMobileLog);
+	const mobileActiveBreaks = activeBreaks.map(toMobileLog);
 
 	return (
 		<MobileTimeClock


### PR DESCRIPTION
## Summary
- add a dedicated route module for `/floor/time-clock/mobile`
- wire route config so mobile redirect resolves to an actual page
- hydrate mobile view with floor data + task assignment context
- closes #18

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- low to medium: new route path and data mapping for mobile time clock