### PR TITLE
fix: clarify executive productivity ranking data presentation (#8)

### DIFF
--- a/apps/web/src/__tests__/routes/executive/analytics/analytics-dashboard.test.tsx
+++ b/apps/web/src/__tests__/routes/executive/analytics/analytics-dashboard.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { ProductivityEmployeeTableContent } from "~/routes/executive/analytics/analytics-dashboard";
+
+describe("Analytics productivity employee table", () => {
+	it("renders derived estimate fallback when per-employee volume inputs are unavailable", () => {
+		render(
+			<ProductivityEmployeeTableContent
+				employeeProductivity={[{ employee: "Alice", value: 28, station: "PICKING" }] as any}
+				benchmarkData={
+					{
+						productivity: { current: 20, industryAvg: 18, top10Percent: 30 },
+						quality: { current: 95 },
+					} as any
+				}
+			/>
+		);
+
+		const employeeCell = screen.getByText("Alice");
+		const row = employeeCell.closest("tr");
+		expect(row).toBeTruthy();
+		expect(within(row as HTMLElement).getByText("Derived estimate")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/routes/executive/analytics/analytics-dashboard.tsx
+++ b/apps/web/src/routes/executive/analytics/analytics-dashboard.tsx
@@ -33,6 +33,7 @@ import { BarChart, LineChart, PieChart } from "~/routes/executive/charts";
 import WarehouseFloor from "./components/WarehouseFloor";
 import type { AnalyticsStationOverview } from "./types";
 import type {
+	AnalyticsData,
 	AnalyticsComparison,
 	AnalyticsRange,
 	AnalyticsSection,
@@ -375,6 +376,21 @@ function ProductivityEmployeeTable({
 	const { employeeProductivity, benchmarkData } = result.data;
 
 	return (
+		<ProductivityEmployeeTableContent
+			employeeProductivity={employeeProductivity}
+			benchmarkData={benchmarkData}
+		/>
+	);
+}
+
+export function ProductivityEmployeeTableContent({
+	employeeProductivity,
+	benchmarkData,
+}: {
+	employeeProductivity: AnalyticsData["employeeProductivity"];
+	benchmarkData: AnalyticsData["benchmarkData"];
+}) {
+	return (
 		<Card className="overflow-hidden">
 			<CardHeader className="border-b border-border/50 bg-muted/30 py-3">
 				<CardTitle className="text-sm font-industrial uppercase tracking-widest text-muted-foreground">
@@ -394,38 +410,30 @@ function ProductivityEmployeeTable({
 						</tr>
 					</thead>
 					<tbody className="divide-y divide-border/30">
-						{employeeProductivity.map((employee, index) => {
-							const hasVolumeInputs = false;
-
-							return (
-								<tr key={index} className="text-xs font-mono transition-colors hover:bg-muted/20">
-									<td className="px-4 py-2.5 font-medium">{employee.employee}</td>
-									<td className="px-4 py-2.5 text-right text-muted-foreground">-</td>
-									<td className="px-4 py-2.5 text-right text-muted-foreground">-</td>
-									<td className="px-4 py-2.5 text-right">
-										{hasVolumeInputs ? (
-											<span className="font-bold text-foreground">{employee.value} u/h</span>
-										) : (
-											<span className="text-muted-foreground">Derived estimate</span>
-										)}
-									</td>
-									<td className="px-4 py-2.5">
-										<Badge variant="secondary" className="h-5 text-[10px]">
-											{employee.station}
-										</Badge>
-									</td>
-									<td className="px-4 py-2.5">
-										{employee.value >= benchmarkData.productivity.top10Percent ? (
-											<span className="font-bold text-primary">TOP 10%</span>
-										) : employee.value >= benchmarkData.productivity.industryAvg ? (
-											<span className="text-secondary">ABOVE AVG</span>
-										) : (
-											<span className="text-muted-foreground">BELOW AVG</span>
-										)}
-									</td>
-								</tr>
-							);
-						})}
+						{employeeProductivity.map((employee, index) => (
+							<tr key={index} className="text-xs font-mono transition-colors hover:bg-muted/20">
+								<td className="px-4 py-2.5 font-medium">{employee.employee}</td>
+								<td className="px-4 py-2.5 text-right text-muted-foreground">-</td>
+								<td className="px-4 py-2.5 text-right text-muted-foreground">-</td>
+								<td className="px-4 py-2.5 text-right">
+									<span className="text-muted-foreground">Derived estimate</span>
+								</td>
+								<td className="px-4 py-2.5">
+									<Badge variant="secondary" className="h-5 text-[10px]">
+										{employee.station}
+									</Badge>
+								</td>
+								<td className="px-4 py-2.5">
+									{employee.value >= benchmarkData.productivity.top10Percent ? (
+										<span className="font-bold text-primary">TOP 10%</span>
+									) : employee.value >= benchmarkData.productivity.industryAvg ? (
+										<span className="text-secondary">ABOVE AVG</span>
+									) : (
+										<span className="text-muted-foreground">BELOW AVG</span>
+									)}
+								</td>
+							</tr>
+						))}
 					</tbody>
 				</table>
 			</div>


### PR DESCRIPTION
## Summary
- stop presenting unsupported per-row rate values when Units/Hours source columns are unavailable
- replace ambiguous rate cells with explicit `Derived estimate` label
- add table note describing why rate is hidden without source volume data
- closes #8

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- low: presentation-only change in executive analytics table