### PR TITLE
fix: synchronize executive analytics period/comparison state (#7)

### DIFF
--- a/apps/web/src/__tests__/routes/executive/analytics/tab-query-normalization.test.ts
+++ b/apps/web/src/__tests__/routes/executive/analytics/tab-query-normalization.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { normalizeComparisonForRange } from "~/routes/executive/time-range-tabs";
+import { getNormalizedComparison } from "~/routes/executive/analytics/comparison-tabs";
+
+describe("executive analytics query normalization", () => {
+	it("keeps valid compare when range changes", () => {
+		expect(normalizeComparisonForRange("month", "rolling-30d")).toBe("rolling-30d");
+	});
+
+	it("falls back to default compare when compare is missing", () => {
+		expect(normalizeComparisonForRange("week", null)).toBe("previous-period");
+	});
+
+	it("normalizes invalid compare to the first available option", () => {
+		expect(getNormalizedComparison(["previous-period", "last-year"], "rolling-30d")).toBe(
+			"previous-period"
+		);
+	});
+});

--- a/apps/web/src/routes/executive/analytics/comparison-tabs.tsx
+++ b/apps/web/src/routes/executive/analytics/comparison-tabs.tsx
@@ -4,10 +4,9 @@ import { startTransition, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router";
 import { Tabs, TabList, Tab } from "@monorepo/design-system";
 import { cn } from "~/lib/cn";
+import type { AnalyticsComparison } from "./model";
 
-type ComparisonBasis = "previous-period" | "last-year" | "rolling-30d";
-
-const comparisonOptions: Array<{ id: ComparisonBasis; label: string }> = [
+const comparisonOptions: Array<{ id: AnalyticsComparison; label: string }> = [
 	{ id: "previous-period", label: "Prev Period" },
 	{ id: "last-year", label: "Last Year" },
 	{ id: "rolling-30d", label: "Rolling 30d" },
@@ -15,7 +14,18 @@ const comparisonOptions: Array<{ id: ComparisonBasis; label: string }> = [
 
 interface ComparisonTabsProps {
 	className?: string;
-	availableOptions?: ComparisonBasis[];
+	availableOptions?: AnalyticsComparison[];
+}
+
+export function getNormalizedComparison(
+	availableOptions: AnalyticsComparison[],
+	requested: string | null
+): AnalyticsComparison {
+	if (requested && availableOptions.some((option) => option === requested)) {
+		return requested as AnalyticsComparison;
+	}
+
+	return availableOptions[0] ?? "previous-period";
 }
 
 export function ComparisonTabs({ className, availableOptions }: ComparisonTabsProps) {
@@ -26,12 +36,11 @@ export function ComparisonTabs({ className, availableOptions }: ComparisonTabsPr
 		? comparisonOptions.filter((opt) => availableOptions.includes(opt.id))
 		: comparisonOptions;
 
-	const currentCompareParam = searchParams.get("compare") as ComparisonBasis | null;
-	const currentCompare: ComparisonBasis = visibleOptions.some(
-		(option) => option.id === currentCompareParam
-	)
-		? (currentCompareParam as ComparisonBasis)
-		: (visibleOptions[0]?.id ?? "previous-period");
+	const currentCompareParam = searchParams.get("compare") as AnalyticsComparison | null;
+	const currentCompare = getNormalizedComparison(
+		visibleOptions.map((option) => option.id),
+		currentCompareParam
+	);
 
 	useEffect(() => {
 		if (!visibleOptions.length) {
@@ -44,7 +53,9 @@ export function ComparisonTabs({ className, availableOptions }: ComparisonTabsPr
 
 		const nextSearchParams = new URLSearchParams(searchParams);
 		nextSearchParams.set("compare", currentCompare);
-		navigate(`?${nextSearchParams.toString()}`, { replace: true });
+		startTransition(() => {
+			navigate(`?${nextSearchParams.toString()}`, { replace: true });
+		});
 	}, [currentCompare, currentCompareParam, navigate, searchParams, visibleOptions.length]);
 
 	const handleComparisonChange = (key: string | number) => {

--- a/apps/web/src/routes/executive/time-range-tabs.tsx
+++ b/apps/web/src/routes/executive/time-range-tabs.tsx
@@ -12,6 +12,22 @@ import {
 
 export type TimeRange = "today" | "week" | "month" | "quarter";
 
+export function normalizeComparisonForRange(
+	range: TimeRange,
+	compare: string | null
+): AnalyticsComparison {
+	const allowed = COMPARISON_COMPATIBILITY[range];
+	if (compare && allowed.includes(compare as AnalyticsComparison)) {
+		return compare as AnalyticsComparison;
+	}
+
+	if (allowed.includes(DEFAULT_COMPARE)) {
+		return DEFAULT_COMPARE;
+	}
+
+	return allowed[0];
+}
+
 interface TimeRangeTabsProps {
 	ranges?: readonly TimeRange[];
 	defaultRange?: TimeRange;
@@ -33,11 +49,8 @@ export function TimeRangeTabs({
 		const nextSearchParams = new URLSearchParams(searchParams);
 		nextSearchParams.set("range", nextRange);
 
-		const compareParam = searchParams.get("compare") as AnalyticsComparison | null;
-		const validComparisons = COMPARISON_COMPATIBILITY[nextRange];
-		if (!compareParam || !validComparisons.includes(compareParam)) {
-			nextSearchParams.set("compare", DEFAULT_COMPARE);
-		}
+		const compareParam = searchParams.get("compare");
+		nextSearchParams.set("compare", normalizeComparisonForRange(nextRange, compareParam));
 
 		startTransition(() => {
 			navigate(`?${nextSearchParams.toString()}`, { replace: false });


### PR DESCRIPTION
## Summary
- normalize `compare` query param whenever selected period changes to an incompatible window
- auto-repair invalid comparison query state in the comparison tabs component
- wrap query navigations in transitions for smoother state updates
- closes #7

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- low: focused query-param synchronization behavior for analytics controls