### PR TITLE
fix: add worker self-task controls to primary floor workflow (#19)

### DIFF
--- a/apps/web/src/components/time-tracking/time-tracking.tsx
+++ b/apps/web/src/components/time-tracking/time-tracking.tsx
@@ -1543,6 +1543,7 @@ export function TimeTracking({
 	activeTasksByEmployee,
 	assignmentMode,
 	taskOptions,
+	workerEmployeeId,
 }: {
 	employees: Employee[];
 	stations: Station[];
@@ -1556,6 +1557,7 @@ export function TimeTracking({
 	>;
 	assignmentMode: TaskAssignmentMode;
 	taskOptions: TaskOption[];
+	workerEmployeeId?: string | null;
 }) {
 	const getStatusBarOffset = () => {
 		if (typeof document === "undefined") {
@@ -1593,6 +1595,10 @@ export function TimeTracking({
 	const apiKey =
 		typeof window !== "undefined" ? window.localStorage.getItem("timeClock:apiKey") || "" : "";
 	const { queue, enqueue, sync, status } = useOfflineActionQueue(apiKey);
+	const workerActiveLog = workerEmployeeId
+		? optimisticLogs.find((log) => log.employeeId === workerEmployeeId)
+		: null;
+	const workerActiveTask = workerEmployeeId ? activeTasksByEmployee?.[workerEmployeeId] : undefined;
 
 	useEffect(() => {
 		const unsub = subscribe((message, type) => {
@@ -1696,6 +1702,25 @@ export function TimeTracking({
 						pinInputRef={pinInputRef}
 						onOptimisticClockIn={addOptimisticLog}
 					/>
+
+					{workerEmployeeId && workerActiveLog && (
+						<Card className="mt-4 border-primary/40">
+							<CardHeader>
+								<CardTitle className="text-sm uppercase tracking-wider">My Task Controls</CardTitle>
+							</CardHeader>
+							<CardBody>
+								<p className="mb-3 text-xs text-muted-foreground">
+									Manage your own task directly from the primary floor screen.
+								</p>
+								<WorkerTaskControls
+									employeeId={workerEmployeeId}
+									activeTask={workerActiveTask}
+									assignmentMode={assignmentMode}
+									taskOptions={taskOptions}
+								/>
+							</CardBody>
+						</Card>
+					)}
 				</div>
 
 				{/* Drawer Overlay */}

--- a/apps/web/src/routes/floor/route.tsx
+++ b/apps/web/src/routes/floor/route.tsx
@@ -4,6 +4,7 @@ import { KioskRedirect } from "~/routes/time-clock/kiosk-redirect";
 import type { Employee, Station, TimeLog } from "@prisma/client";
 import { ensureOperationalDataSeeded } from "~/lib/ensure-operational-data";
 import { getTaskAssignmentMode } from "~/lib/operational-config";
+import { validateRequest } from "~/lib/auth";
 
 type TimeLogWithRelations = TimeLog & {
 	Employee: Employee;
@@ -48,6 +49,7 @@ export default async function Component() {
 		stations,
 		activeLogs,
 		activeBreaks,
+		auth,
 		assignmentMode,
 		activeTaskTypes,
 		activeAssignments,
@@ -72,6 +74,7 @@ export default async function Component() {
 			include: { Employee: true, Station: true },
 			orderBy: { startTime: "desc" },
 		}),
+		validateRequest(),
 		getTaskAssignmentMode(),
 		db.taskType.findMany({
 			where: { isActive: true },
@@ -111,6 +114,8 @@ export default async function Component() {
 		},
 		{}
 	);
+
+	const workerEmployeeId = auth.user?.role === "WORKER" ? auth.user.employeeId : null;
 
 	return (
 		<>
@@ -153,6 +158,7 @@ export default async function Component() {
 							activeTasksByEmployee={activeTasksByEmployee}
 							assignmentMode={assignmentMode}
 							taskOptions={taskOptions}
+							workerEmployeeId={workerEmployeeId}
 						/>
 					</div>
 				</main>


### PR DESCRIPTION
## Summary
- pass authenticated worker context into floor time-tracking view
- surface worker self-task controls directly in the primary floor screen (not only secondary/drawer UI)
- preserve assignment-mode gating and existing task action behavior
- closes #19

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- low to medium: worker-focused rendering path added to floor time-tracking UI