### PR TITLE
fix: shift worker landing to personal status-first UX (#20)

### DIFF
--- a/apps/web/src/components/time-tracking/time-tracking.tsx
+++ b/apps/web/src/components/time-tracking/time-tracking.tsx
@@ -1853,38 +1853,31 @@ function WorkerStatusFirstCard({
 	workerOnBreak: boolean;
 	workerActiveTask?: { assignmentId: string; taskTypeName: string; stationName: string | null };
 }) {
-	if (!workerActiveLog) {
-		return (
-			<Card className="border-primary/40 bg-primary/5">
-				<CardHeader>
-					<CardTitle className="text-sm uppercase tracking-wider">My Status</CardTitle>
-				</CardHeader>
-				<CardBody>
-					<p className="text-sm text-muted-foreground">
-						Clock in to start your shift and access personal task controls.
-					</p>
-				</CardBody>
-			</Card>
-		);
-	}
-
 	return (
 		<Card className="border-primary/40 bg-primary/5">
 			<CardHeader>
 				<CardTitle className="text-sm uppercase tracking-wider">My Status</CardTitle>
 			</CardHeader>
-			<CardBody className="space-y-2 text-sm">
-				<p>
-					<span className="font-medium">Station:</span>{" "}
-					{workerActiveLog.Station?.name || "Unassigned"}
-				</p>
-				<p>
-					<span className="font-medium">Break:</span> {workerOnBreak ? "On break" : "Working"}
-				</p>
-				<p>
-					<span className="font-medium">Task:</span>{" "}
-					{workerActiveTask ? workerActiveTask.taskTypeName : "No active task"}
-				</p>
+			<CardBody className={workerActiveLog ? "space-y-2 text-sm" : undefined}>
+				{!workerActiveLog ? (
+					<p className="text-sm text-muted-foreground">
+						Clock in to start your shift and access personal task controls.
+					</p>
+				) : (
+					<>
+						<p>
+							<span className="font-medium">Station:</span>{" "}
+							{workerActiveLog.Station?.name || "Unassigned"}
+						</p>
+						<p>
+							<span className="font-medium">Break:</span> {workerOnBreak ? "On break" : "Working"}
+						</p>
+						<p>
+							<span className="font-medium">Task:</span>{" "}
+							{workerActiveTask ? workerActiveTask.taskTypeName : "No active task"}
+						</p>
+					</>
+				)}
 			</CardBody>
 		</Card>
 	);


### PR DESCRIPTION
## Summary
- add a worker-focused status card at top of floor landing with personal station/break/task context
- hide operations-heavy top actions (roster/logs/kiosk launch) for worker sessions
- keep manager/ops controls unchanged for non-worker views
- closes #20

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run typecheck

## Risk
- medium: worker-only UI composition changes on the primary floor screen

## Dependency
- stacks on #35 (worker context plumbing + self-task primary controls)